### PR TITLE
Grid cell details

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -3,6 +3,10 @@
   background-color: #9F9F9F;
 }
 
+.op-code-table tbody {
+  font-family: monospace;
+}
+
 .op-code-table th {
   border: 1px solid black;
 }
@@ -13,6 +17,11 @@
 
 .instruction {
   background-color: #BFBFBF;
+  text-align: center;
+}
+
+.instruction span {
+  display: block;
 }
 
 .eight-bit-transfer-and-io {

--- a/src/components/instruction-cell/index.js
+++ b/src/components/instruction-cell/index.js
@@ -1,0 +1,12 @@
+const InstructionCell = props => {
+  const { instruction } = props;
+  return (
+    <td
+      className={`instruction ${instruction.type}`}
+    >
+      <span className='mnemonic'>{instruction.mnemonic}</span>
+    </td>
+  );
+};
+
+export default InstructionCell;

--- a/src/components/instruction-cell/index.js
+++ b/src/components/instruction-cell/index.js
@@ -1,10 +1,20 @@
 const InstructionCell = props => {
   const { instruction } = props;
+
+  const z = instruction.flags.Z || '-';
+  const n = instruction.flags.N || '-';
+  const h = instruction.flags.H || '-';
+  const cy = instruction.flags.CY || '-';
+
   return (
     <td
       className={`instruction ${instruction.type}`}
     >
-      <span className='mnemonic'>{instruction.mnemonic}</span>
+      <div>
+        <span className='mnemonic'>{instruction.mnemonic}</span>
+        <span className='cycles'>{instruction.cycles}</span>
+        <span className="flags">{`${z} ${n} ${h} ${cy}`}</span>
+      </div>
     </td>
   );
 };

--- a/src/components/instruction-cell/index.spec.js
+++ b/src/components/instruction-cell/index.spec.js
@@ -45,7 +45,11 @@ describe('InstructionCell', () => {
 
   it.todo('renders the number of bytes');
 
-  it.todo('renders the number of cycles');
+  it('renders the number of cycles', () => {
+    expect(component.find('.cycles')).toHaveLength(1);
+  });
 
-  it.todo('renders the instruction flags');
+  it('renders the instruction flags', () => {
+    expect(component.find('.flags')).toHaveLength(1);
+  });
 });

--- a/src/components/instruction-cell/index.spec.js
+++ b/src/components/instruction-cell/index.spec.js
@@ -1,0 +1,51 @@
+import { mount } from 'enzyme';
+import InstructionCell from '.';
+
+describe('InstructionCell', () => {
+  let component;
+
+  const instruction = {
+    mnemonic: 'TEST MNEMONIC',
+    type: 'test-instruction-type',
+    flags: {
+      CY: 'CY',
+      H: 'H',
+      N: 'N',
+      Z: 'Z',
+    },
+    cycles: '4',
+  }
+
+  beforeAll(() => {
+    component = mount(
+      <table>
+        <tbody>
+          <tr>
+            <InstructionCell instruction={instruction} />
+          </tr>
+        </tbody>
+      </table>
+    );
+  });
+  it('renders a td element with the instruction class', () => {
+    expect(component.find('td')).toHaveLength(1);
+    expect(component.find('.instruction')).toHaveLength(1);
+  });
+  
+  it('renders the instruction mnemonic', () => {
+    expect(component.find('.mnemonic')).toHaveLength(1);
+    expect(component.find('.mnemonic').text()).toEqual(instruction.mnemonic);
+  });
+
+  it('adds the instruction type as a class name', () => {
+    expect(component.find(`.${instruction.type}`)).toHaveLength(1);
+  })
+
+  it.todo('adds a visually hidden instruction type (for screen readers)')
+
+  it.todo('renders the number of bytes');
+
+  it.todo('renders the number of cycles');
+
+  it.todo('renders the instruction flags');
+});

--- a/src/components/op-code-table/index.js
+++ b/src/components/op-code-table/index.js
@@ -1,3 +1,5 @@
+import InstructionCell from "../instruction-cell";
+
 const OpCodeTable = ({ opCodesGrid, caption }) => (
   <table className="op-code-table">
     <caption>{ caption }</caption>
@@ -15,16 +17,23 @@ const OpCodeTable = ({ opCodesGrid, caption }) => (
           <tr key={`${rowIndex.toString(16)}x`}>
             <th scope="row">{`${rowIndex.toString(16).toUpperCase()}x`}</th>
             {
-              gridRow.map((gridCell, columnIndex) => (
-                <td
-                  key={`${rowIndex}${columnIndex}`}
-                  className={`instruction ${gridCell.type}`}
-                >
-                {
-                  gridCell.mnemonic ? gridCell.mnemonic : gridCell
+              gridRow.map((gridCell, columnIndex) => {
+                const cellKey = `${rowIndex}${columnIndex}`;
+                const doesCellContainInstruction = typeof(gridCell) === "object";
+
+                if (doesCellContainInstruction) {
+                  return (
+                    <InstructionCell
+                      key={cellKey}
+                      instruction={gridCell}
+                    />
+                  );
+                } else {
+                  return (
+                    <td key={cellKey} className="instruction"></td>
+                  );
                 }
-                </td>
-              ))
+              })
             }
           </tr>
         ))

--- a/src/components/op-code-table/index.spec.js
+++ b/src/components/op-code-table/index.spec.js
@@ -1,9 +1,30 @@
 import OpCodeTable from '.';
+import InstructionCell from '../instruction-cell';
 import { mount } from 'enzyme';
 
 describe('OpCodeTable', () => {
   let component;
   let grid;
+  const instructions = [
+    {
+      mnemonic: 'TEST1',
+      type: 'test-type',
+      flags: {},
+      cycles: '1',
+    },
+    {
+      mnemonic: 'TEST2',
+      type: 'test-type',
+      flags: {},
+      cycles: '1',
+    },
+    {
+      mnemonic: 'TEST3',
+      type: 'test-type',
+      flags: {},
+      cycles: '1',
+    },
+  ]
 
   beforeAll(() => {
     grid = new Array(16);
@@ -13,6 +34,10 @@ describe('OpCodeTable', () => {
         grid[i][j] = '';
       }
     }
+
+    grid[3][8] = instructions[0];
+    grid[4][5] = instructions[1];
+    grid[6][8] = instructions[2];
 
     component = mount(<OpCodeTable opCodesGrid={grid} />);
   });
@@ -26,4 +51,7 @@ describe('OpCodeTable', () => {
   it('renders the right number of cells in the table', () => {
     expect(component.find('td.instruction')).toHaveLength(16*16);
   });
+  it('renders the right number of InstructionCell components', () => {
+    expect(component.find(InstructionCell)).toHaveLength(instructions.length);
+  })
 });


### PR DESCRIPTION
Expand grid cells to include additional instruction details, instead of just including the instruction mnemonic.